### PR TITLE
fixed gcc (arm-poky-linux-gnueabi-gcc (Linaro GCC 4.8-2014.04) 4.8.3 …

### DIFF
--- a/egl_wrapper.cc
+++ b/egl_wrapper.cc
@@ -49,7 +49,7 @@ static EGLDisplay g_EglDisplay = NULL;
 static EGLContext g_EglContext = NULL;
 static EGLSurface g_EglSurface = NULL;
 
-static NativeDisplayType g_NativeDisplay= NULL;
+static NativeDisplayType g_NativeDisplay= EGL_DEFAULT_DISPLAY;
 static NativeWindowType g_NativeWindow;
 
 static int g_WindowWidth=0;


### PR DESCRIPTION
Hi Zoltan!

I tried to compile your repository and had to fix the following compiler error:

../../ui/ozone/platform/egl/egl_wrapper.cc:52:43: error: converting to non-pointer type 'int' from NULL [-Werror=conversion-null]
 static NativeDisplayType g_NativeDisplay= NULL;
                                                                     ^

Probably you would like to fix it in your master as well!

Best regards,
Sven
